### PR TITLE
Hotfix/lease cleanup

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -1118,6 +1118,8 @@ public class Scheduler implements Runnable {
                 (StreamProcessingMode.MULTI_STREAM_MODE == streamProcessingMode) ? 1 : 0,
                 MetricsLevel.DETAILED);
             MetricsUtil.addWorkerIdentifier(metricsScope, leaseManagementConfig.workerIdentifier());
+            MetricsUtil.addCount(metricsScope, RetrievalConfig.KINESIS_CLIENT_LIB_USER_AGENT_VERSION, 1,
+                MetricsLevel.DETAILED);
             MetricsUtil.endScope(metricsScope);
             emitWorkerMetricsWatch.reset().start();
         }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/HierarchicalShardSyncer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/HierarchicalShardSyncer.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
@@ -78,6 +79,7 @@ public class HierarchicalShardSyncer {
 
     private final DeletedStreamListProvider deletedStreamListProvider;
 
+    @Getter
     private final StreamProcessingMode streamProcessingMode;
 
     private final boolean createMultiStreamLease;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseRefresher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/LeaseRefresher.java
@@ -15,6 +15,7 @@
 package software.amazon.kinesis.leases;
 
 import java.util.List;
+import java.util.Optional;
 
 import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.leases.exceptions.DependencyException;
@@ -253,6 +254,21 @@ public interface LeaseRefresher {
      * @throws ProvisionedThroughputException
      */
     default void replaceLease(Lease oldLease, Lease newLease)
+            throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Retrieve lease from shard Id and stream identifier. This method is useful when lease key is
+     * not known and can be either one of the two known formats (single-stream or multi-stream).
+     * @param shardId
+     * @param streamIdentifierSerOpt
+     * @return lease
+     * @throws DependencyException
+     * @throws InvalidStateException
+     * @throws ProvisionedThroughputException
+     */
+    default Lease getLeaseFromShard(String shardId, Optional<String> streamIdentifierSerOpt)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         throw new UnsupportedOperationException();
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/BlockOnParentShardTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/BlockOnParentShardTask.java
@@ -58,8 +58,7 @@ public class BlockOnParentShardTask implements ConsumerTask {
         try {
             boolean blockedOnParentShard = false;
             for (String shardId : shardInfo.parentShardIds()) {
-                final String leaseKey = ShardInfo.getLeaseKey(shardInfo, shardId);
-                final Lease lease = leaseRefresher.getLease(leaseKey);
+                final Lease lease = leaseRefresher.getLeaseFromShard(shardId, shardInfo.streamIdentifierSerOpt());
                 if (lease != null) {
                     ExtendedSequenceNumber checkpoint = lease.checkpoint();
                     if ((checkpoint == null) || (!checkpoint.equals(ExtendedSequenceNumber.SHARD_END))) {

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -1240,6 +1240,7 @@ public class SchedulerTest {
         verify(metricsScope).addData("SingleStreamCompatibleMode", 0, StandardUnit.COUNT, MetricsLevel.DETAILED);
         verify(metricsScope).addData("SingleStreamUpgradeMode", 0, StandardUnit.COUNT, MetricsLevel.DETAILED);
         verify(metricsScope).addData("MultiStreamMode", 0, StandardUnit.COUNT, MetricsLevel.DETAILED);
+        verify(metricsScope).addData(RetrievalConfig.KINESIS_CLIENT_LIB_USER_AGENT_VERSION, 1, StandardUnit.COUNT, MetricsLevel.DETAILED);
         verify(metricsScope).addDimension("WorkerIdentifier", "workerIdentifier");
         verify(metricsScope).end();
         verifyNoMoreInteractions(metricsScope);

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/BlockOnParentShardTaskTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/lifecycle/BlockOnParentShardTaskTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +61,7 @@ public class BlockOnParentShardTaskTest {
     public final void testCallNoParents()
         throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         LeaseRefresher leaseRefresher = mock(LeaseRefresher.class);
-        when(leaseRefresher.getLease(shardId)).thenReturn(null);
+        when(leaseRefresher.getLeaseFromShard(shardId, Optional.empty())).thenReturn(null);
 
         BlockOnParentShardTask task = new BlockOnParentShardTask(shardInfo, leaseRefresher, backoffTimeInMillis);
         TaskResult result = task.call();
@@ -89,8 +90,8 @@ public class BlockOnParentShardTaskTest {
         parent2Lease.checkpoint(ExtendedSequenceNumber.SHARD_END);
 
         LeaseRefresher leaseRefresher = mock(LeaseRefresher.class);
-        when(leaseRefresher.getLease(parent1ShardId)).thenReturn(parent1Lease);
-        when(leaseRefresher.getLease(parent2ShardId)).thenReturn(parent2Lease);
+        when(leaseRefresher.getLeaseFromShard(parent1ShardId, Optional.empty())).thenReturn(parent1Lease);
+        when(leaseRefresher.getLeaseFromShard(parent2ShardId, Optional.empty())).thenReturn(parent2Lease);
 
         // test single parent
         parentShardIds.add(parent1ShardId);
@@ -118,8 +119,6 @@ public class BlockOnParentShardTaskTest {
             throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         ShardInfo shardInfo = null;
         BlockOnParentShardTask task = null;
-        String parent1LeaseKey = streamId + ":" + "shardId-1";
-        String parent2LeaseKey = streamId + ":" + "shardId-2";
         String parent1ShardId = "shardId-1";
         String parent2ShardId = "shardId-2";
         List<String> parentShardIds = new ArrayList<>();
@@ -131,8 +130,8 @@ public class BlockOnParentShardTaskTest {
         parent2Lease.checkpoint(ExtendedSequenceNumber.SHARD_END);
 
         LeaseRefresher leaseRefresher = mock(LeaseRefresher.class);
-        when(leaseRefresher.getLease(parent1LeaseKey)).thenReturn(parent1Lease);
-        when(leaseRefresher.getLease(parent2LeaseKey)).thenReturn(parent2Lease);
+        when(leaseRefresher.getLeaseFromShard(parent1ShardId, Optional.of(streamId))).thenReturn(parent1Lease);
+        when(leaseRefresher.getLeaseFromShard(parent2ShardId, Optional.of(streamId))).thenReturn(parent2Lease);
 
         // test single parent
         parentShardIds.add(parent1ShardId);
@@ -173,8 +172,8 @@ public class BlockOnParentShardTaskTest {
         parent2Lease.checkpoint(new ExtendedSequenceNumber("98182584034"));
 
         LeaseRefresher leaseRefresher = mock(LeaseRefresher.class);
-        when(leaseRefresher.getLease(parent1ShardId)).thenReturn(parent1Lease);
-        when(leaseRefresher.getLease(parent2ShardId)).thenReturn(parent2Lease);
+        when(leaseRefresher.getLeaseFromShard(parent1ShardId, Optional.empty())).thenReturn(parent1Lease);
+        when(leaseRefresher.getLeaseFromShard(parent2ShardId, Optional.empty())).thenReturn(parent2Lease);
 
         // test single parent
         parentShardIds.add(parent1ShardId);
@@ -203,8 +202,6 @@ public class BlockOnParentShardTaskTest {
 
         ShardInfo shardInfo = null;
         BlockOnParentShardTask task = null;
-        String parent1LeaseKey = streamId + ":" + "shardId-1";
-        String parent2LeaseKey = streamId + ":" + "shardId-2";
         String parent1ShardId = "shardId-1";
         String parent2ShardId = "shardId-2";
         List<String> parentShardIds = new ArrayList<>();
@@ -217,8 +214,8 @@ public class BlockOnParentShardTaskTest {
         parent2Lease.checkpoint(new ExtendedSequenceNumber("98182584034"));
 
         LeaseRefresher leaseRefresher = mock(LeaseRefresher.class);
-        when(leaseRefresher.getLease(parent1LeaseKey)).thenReturn(parent1Lease);
-        when(leaseRefresher.getLease(parent2LeaseKey)).thenReturn(parent2Lease);
+        when(leaseRefresher.getLeaseFromShard(parent1ShardId, Optional.of(streamId))).thenReturn(parent1Lease);
+        when(leaseRefresher.getLeaseFromShard(parent2ShardId, Optional.of(streamId))).thenReturn(parent2Lease);
 
         // test single parent
         parentShardIds.add(parent1ShardId);
@@ -253,7 +250,7 @@ public class BlockOnParentShardTaskTest {
         TaskResult result = null;
         Lease parentLease = new Lease();
         LeaseRefresher leaseRefresher = mock(LeaseRefresher.class);
-        when(leaseRefresher.getLease(parentShardId)).thenReturn(parentLease);
+        when(leaseRefresher.getLeaseFromShard(parentShardId, Optional.empty())).thenReturn(parentLease);
 
         // test when parent shard has not yet been fully processed
         parentLease.checkpoint(new ExtendedSequenceNumber("98182584034"));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Change 1:
Fix lease cleanup in SingleStreamCompatibleMode.

This change updates lease cleanup logic to look at both types of leases
when attempting to find child shards for a parent lease that has reached
end of processing. A method is added to LeaseRefresher to retrieve a
lease using shard Id.

Change 2:
Fix lease creation during shard merge in new modes

This change updates consumer shutdown task to look at both types of
parent leases when attempting to create a child lease during a shard
merge. This is relevant for the new modes added to support live
migration to multi-stream processing.

Change 3:
Look up all types of leases when locating parents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
